### PR TITLE
beegfs::install Remove hardcoded call to "apt"

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,7 +41,6 @@ class beegfs::install(
 
   package { 'beegfs-utils':
     ensure  => $package_ensure,
-    require => [Anchor['beegfs::apt_repo'], Exec['apt_update']], # TODO: this will work only on Debian
   }
 
 }


### PR DESCRIPTION
This only works on Debian systems.
An explciit refresh of apt should in any case not be needed. 