### PR TITLE
beegfs::mount Remove ensure parameter from concat::fragment

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -18,7 +18,6 @@ define beegfs::mount (
   }
 
   concat::fragment { $mnt:
-    ensure  => present,
     target  => $mounts_cfg,
     content => "${mnt} ${cfg}",
     require => File[$mnt],


### PR DESCRIPTION
This attribute is unsupported in current versions. 