### PR TITLE
Fix log directories

### DIFF
--- a/templates/6/beegfs-meta.conf.erb
+++ b/templates/6/beegfs-meta.conf.erb
@@ -46,7 +46,7 @@ logLevel                     = <%= @log_level %>
 logNoDate                    = false
 logNumLines                  = 50000
 logNumRotatedFiles           = 5
-logStdFile                   = /var/log/beegfs-meta.log
+logStdFile                   = <%= @log_dir %>/beegfs-meta.log
 
 runDaemonized                = true
 

--- a/templates/6/beegfs-mgmtd.conf.erb
+++ b/templates/6/beegfs-mgmtd.conf.erb
@@ -37,7 +37,7 @@ logLevel                               = <%= @log_level %>
 logNoDate                              = false
 logNumLines                            = 50000
 logNumRotatedFiles                     = 5
-logStdFile                             = <%= @log_dir %>/mgmtd.log
+logStdFile                             = <%= @log_dir %>/beegfs-mgmtd.log
 
 quotaQueryGIDRange                     =
 quotaQueryUIDRange                     =

--- a/templates/6/beegfs-storage.conf.erb
+++ b/templates/6/beegfs-storage.conf.erb
@@ -45,7 +45,7 @@ logLevel                     = <%= @log_level %>
 logNoDate                    = false
 logNumLines                  = 50000
 logNumRotatedFiles           = 5
-logStdFile                   = /var/log/beegfs-storage.log
+logStdFile                   = <%= @log_dir %>/beegfs-storage.log
 
 quotaEnableEnforcement       = false
 


### PR DESCRIPTION
Log directory setting (for major_version 6) actually was only done for mgmtd. 

Also, change log-file-names to "beegfs-xxx.log", since otherwise, putting the logfiles in `/var/log` would cause a huge mess. 