### PR TITLE
beegfs::storage Add support for multiple storage directories.

### DIFF
--- a/templates/2015.03/beegfs-storage.conf.erb
+++ b/templates/2015.03/beegfs-storage.conf.erb
@@ -16,7 +16,7 @@
 
 sysMgmtdHost                 = <%= @mgmtd_host %>
 
-storeStorageDirectory        = <%= @storage_directory %>
+storeStorageDirectory        = <%= @storage_directory.respond_to?("join") ? @storage_directory.join(",") : @storage_directory %>
 storeAllowFirstRunInit       = true
 
 

--- a/templates/6/beegfs-storage.conf.erb
+++ b/templates/6/beegfs-storage.conf.erb
@@ -16,7 +16,7 @@
 
 sysMgmtdHost                 = <%= @mgmtd_host %>
 
-storeStorageDirectory        = <%= @storage_directory %>
+storeStorageDirectory        = <%= @storage_directory.respond_to?("join") ? @storage_directory.join(",") : @storage_directory %>
 storeAllowFirstRunInit       = true
 
 


### PR DESCRIPTION
If an array is passed, join with comma, else just use the passed string.
If multiple directories should be set, an array has to be used,
since beegfs::storage checks for directory existence, which fails
if a comma-separated string would be passed in.