### PR TITLE
Allow to set "storeAllowFirstRunInit" for meta, mgmtd and storage.

### DIFF
--- a/manifests/meta.pp
+++ b/manifests/meta.pp
@@ -3,17 +3,18 @@
 # This module manages beegfs meta service
 #
 class beegfs::meta (
-  $enable          = true,
-  $meta_directory  = $beegfs::meta_directory,
-  $mgmtd_host      = $beegfs::mgmtd_host,
-  $log_dir         = $beegfs::log_dir,
-  $log_level       = 3,
-  $user            = $beegfs::user,
-  $group           = $beegfs::group,
-  $package_ensure  = hiera('beegfs::package_ensure', $beegfs::package_ensure),
-  $interfaces      = ['eth0'],
-  $interfaces_file = '/etc/beegfs/interfaces.meta',
-  $major_version   = $beegfs::major_version,
+  $enable               = true,
+  $meta_directory       = $beegfs::meta_directory,
+  $allow_first_run_init = true,
+  $mgmtd_host           = $beegfs::mgmtd_host,
+  $log_dir              = $beegfs::log_dir,
+  $log_level            = 3,
+  $user                 = $beegfs::user,
+  $group                = $beegfs::group,
+  $package_ensure       = hiera('beegfs::package_ensure', $beegfs::package_ensure),
+  $interfaces           = ['eth0'],
+  $interfaces_file      = '/etc/beegfs/interfaces.meta',
+  $major_version        = $beegfs::major_version,
 ) inherits ::beegfs {
 
   require ::beegfs::install

--- a/manifests/mgmtd.pp
+++ b/manifests/mgmtd.pp
@@ -5,6 +5,7 @@
 class beegfs::mgmtd (
   $enable                        = true,
   $directory                     = '/srv/beegfs/mgmtd',
+  $allow_first_run_init          = true,
   $client_auto_remove_mins       = $beegfs::client_auto_remove_mins,
   $meta_space_low_limit          = $beegfs::meta_space_low_limit,
   $meta_space_emergency_limit    = $beegfs::meta_space_emergency_limit,

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -3,19 +3,20 @@
 # This module manages beegfs storage service
 #
 class beegfs::storage (
-  $enable            = true,
-  $storage_directory = $beegfs::storage_directory,
-  $mgmtd_host        = $beegfs::mgmtd_host,
-  $log_dir           = $beegfs::log_dir,
-  $log_level         = 3,
-  $user              = $beegfs::user,
-  $group             = $beegfs::group,
-  $package_ensure    = $beegfs::package_ensure,
-  $interfaces        = ['eth0'],
-  $interfaces_file   = '/etc/beegfs/interfaces.storage',
-  $mgmtd_tcp_port    = 8008,
-  $mgmtd_udp_port    = 8008,
-  $major_version     = $beegfs::major_version,
+  $enable               = true,
+  $storage_directory    = $beegfs::storage_directory,
+  $allow_first_run_init = true,
+  $mgmtd_host           = $beegfs::mgmtd_host,
+  $log_dir              = $beegfs::log_dir,
+  $log_level            = 3,
+  $user                 = $beegfs::user,
+  $group                = $beegfs::group,
+  $package_ensure       = $beegfs::package_ensure,
+  $interfaces           = ['eth0'],
+  $interfaces_file      = '/etc/beegfs/interfaces.storage',
+  $mgmtd_tcp_port       = 8008,
+  $mgmtd_udp_port       = 8008,
+  $major_version        = $beegfs::major_version,
 ) inherits ::beegfs {
 
   require ::beegfs::install

--- a/templates/2015.03/beegfs-meta.conf.erb
+++ b/templates/2015.03/beegfs-meta.conf.erb
@@ -17,7 +17,7 @@
 sysMgmtdHost                 = <%= @mgmtd_host %>
 
 storeMetaDirectory           = <%= @meta_directory %>
-storeAllowFirstRunInit       = true
+storeAllowFirstRunInit       = <%= @allow_first_run_init %>
 
 
 #

--- a/templates/2015.03/beegfs-mgmtd.conf.erb
+++ b/templates/2015.03/beegfs-mgmtd.conf.erb
@@ -18,7 +18,7 @@ storeMgmtdDirectory      = <%= @directory %>
 storeAllowFirstRunInit   = true
 
 sysAllowNewServers       = true
-sysAllowNewTargets       = true
+sysAllowNewTargets       = <%= @allow_first_run_init %>
 
 
 #

--- a/templates/2015.03/beegfs-storage.conf.erb
+++ b/templates/2015.03/beegfs-storage.conf.erb
@@ -17,7 +17,7 @@
 sysMgmtdHost                 = <%= @mgmtd_host %>
 
 storeStorageDirectory        = <%= @storage_directory %>
-storeAllowFirstRunInit       = true
+storeAllowFirstRunInit       = <%= @allow_first_run_init %>
 
 
 #

--- a/templates/6/beegfs-meta.conf.erb
+++ b/templates/6/beegfs-meta.conf.erb
@@ -17,7 +17,7 @@
 sysMgmtdHost                 = <%= @mgmtd_host %>
 
 storeMetaDirectory           = <%= @meta_directory %>
-storeAllowFirstRunInit       = true
+storeAllowFirstRunInit       = <%= @allow_first_run_init %>
 
 
 #

--- a/templates/6/beegfs-mgmtd.conf.erb
+++ b/templates/6/beegfs-mgmtd.conf.erb
@@ -15,7 +15,7 @@
 #
 
 storeMgmtdDirectory      = <%= @directory %>
-storeAllowFirstRunInit   = true
+storeAllowFirstRunInit   = <%= @allow_first_run_init %>
 
 sysAllowNewServers       = true
 sysAllowNewTargets       = true

--- a/templates/6/beegfs-storage.conf.erb
+++ b/templates/6/beegfs-storage.conf.erb
@@ -17,7 +17,7 @@
 sysMgmtdHost                 = <%= @mgmtd_host %>
 
 storeStorageDirectory        = <%= @storage_directory %>
-storeAllowFirstRunInit       = true
+storeAllowFirstRunInit       = <%= @allow_first_run_init %>
 
 
 #


### PR DESCRIPTION
Default is true.

This allows to configure Storage and Meta nodes in a "fail-safe" way, i.e. after initial provisioning, one can choose to have the mounts `noauto` and `storeAllowFirstRunInit`to false, so that whatever happens (node crash, unexpected reboot), storage will not be borked before somebody had a manual look. 