### PR TITLE
beegfs::client Let module build depend on presence of client package.

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -72,6 +72,7 @@ class beegfs::client (
     path        => ['/usr/bin', '/usr/sbin'],
     subscribe   => File['/etc/beegfs/beegfs-client-autobuild.conf'],
     refreshonly => true,
+    require     => Package['beegfs-client'],
   }
 
   package { 'beegfs-helperd':


### PR DESCRIPTION
This fixes the problem that the kernel module build might be triggered
before beegfs-client is actually installed.