### PR TITLE
Allowing for use of versions apart from 7.1

### DIFF
--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -9,13 +9,11 @@ class beegfs::repo::redhat (
 
   $_os_release = $facts.dig('os', 'release', 'major')
 
-  # If using the old version pattern the release folder is the same as the major
-  # version; if using the new pattern we need to replace dots (`.`) with spaces
-  # (` `)
-  $_release = if $release =~ /^\d{4}/ {
-    $release
-  } else {
+  # If using version 7.1 the release folder has an underscore instead of a period
+  $_release = if $release == '7.1' {
     $release.regsubst('\.', '_')
+  } else {
+    $release
   }
 
   if $manage_repo {


### PR DESCRIPTION
I'm just getting started with BeeGFS and it seems the release directory format has changed again. I was going to install 7.2 which is the latest and it errored. I think this change should cover the current format.

If you're happy to merge this can you please create a new release and push to the forge.

Cheers.

Trent