### PR TITLE
Add support for connNetFilterFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ beegfs::mount{ 'mnt-share':
 }
 ```
 
-### Interfaces
+### Interfaces and networks
 
-For meta and storage nodes you can specify interfaces for commutication. The passed argument must be an array.
+For meta and storage nodes you can specify interfaces for communication. The passed argument must be an array.
 
 ```puppet
 class { 'beegfs::meta':
@@ -69,6 +69,17 @@ class { 'beegfs::meta':
 class { 'beegfs::storage':
   mgmtd_host => 192.168.1.1,
   interfaces => ['eth0', 'ib0']
+}
+```
+
+In some cases, interfaces can have multiple ips, and only a subset of them should be used. 
+In this case, the list of allowed subnets can be passed as the networks parameter. It should be an array if specified.
+
+```puppet
+class { 'beegfs::meta':
+  mgmtd_host => 192.168.1.1,
+  interfaces => ['eth0', 'ib0'],
+  networks => ['192.168.1.0/24'],
 }
 ```
 

--- a/manifests/admon.pp
+++ b/manifests/admon.pp
@@ -3,30 +3,32 @@
 # This module manages beegfs admon
 #
 class beegfs::admon (
-  Boolean              $enable                   = true,
-  String               $user                     = $beegfs::user,
-  String               $group                    = $beegfs::group,
-  $package_ensure                                = $beegfs::package_ensure,
-  $kernel_ensure                                 = present,
-  Array[String]        $interfaces               = ['eth0'],
-  Stdlib::AbsolutePath $interfaces_file          = '/etc/beegfs/interfaces.admon',
-  Beegfs::LogDir       $log_dir                  = $beegfs::log_dir,
-  Beegfs::LogType      $log_type                 = $beegfs::log_type,
-  Beegfs::LogLevel     $log_level                = $beegfs::log_level,
-  Stdlib::Host         $mgmtd_host               = lookup('beegfs::mgmtd_host', String, undef, $beegfs::mgmtd_host),
-  Stdlib::Port         $admon_http_port          = $beegfs::admon_http_port,
-  Stdlib::Port         $admon_udp_port           = $beegfs::admon_udp_port,
-  Stdlib::Port         $client_udp_port          = $beegfs::client_udp_port,
-  Stdlib::Port         $helperd_tcp_port         = $beegfs::helperd_tcp_port,
-  Stdlib::Port         $mgmtd_tcp_port           = $beegfs::mgmtd_tcp_port,
-  Stdlib::Port         $mgmtd_udp_port           = $beegfs::mgmtd_udp_port,
-  Array[String]        $kernel_packages          = $beegfs::params::kernel_packages,
-  Boolean              $autobuild                = true,
-  String               $autobuild_args           = '-j8',
-  Boolean              $tune_refresh_on_get_attr = false,
-  Boolean              $enable_quota             = $beegfs::enable_quota,
-  Boolean              $enable_acl               = $beegfs::enable_acl,
-  Stdlib::AbsolutePath $admon_db_file            = $beegfs::admon_db_file,
+  Boolean                 $enable                   = true,
+  String                  $user                     = $beegfs::user,
+  String                  $group                    = $beegfs::group,
+  $package_ensure                                   = $beegfs::package_ensure,
+  $kernel_ensure                                    = present,
+  Array[String]           $interfaces               = ['eth0'],
+  Stdlib::AbsolutePath    $interfaces_file          = '/etc/beegfs/interfaces.admon',
+  Optional[Array[String]] $networks                 = undef,
+  Stdlib::AbsolutePath    $networks_file            = '/etc/beegfs/networks.admon',
+  Beegfs::LogDir          $log_dir                  = $beegfs::log_dir,
+  Beegfs::LogType         $log_type                 = $beegfs::log_type,
+  Beegfs::LogLevel        $log_level                = $beegfs::log_level,
+  Stdlib::Host            $mgmtd_host               = lookup('beegfs::mgmtd_host', String, undef, $beegfs::mgmtd_host),
+  Stdlib::Port            $admon_http_port          = $beegfs::admon_http_port,
+  Stdlib::Port            $admon_udp_port           = $beegfs::admon_udp_port,
+  Stdlib::Port            $client_udp_port          = $beegfs::client_udp_port,
+  Stdlib::Port            $helperd_tcp_port         = $beegfs::helperd_tcp_port,
+  Stdlib::Port            $mgmtd_tcp_port           = $beegfs::mgmtd_tcp_port,
+  Stdlib::Port            $mgmtd_udp_port           = $beegfs::mgmtd_udp_port,
+  Array[String]           $kernel_packages          = $beegfs::params::kernel_packages,
+  Boolean                 $autobuild                = true,
+  String                  $autobuild_args           = '-j8',
+  Boolean                 $tune_refresh_on_get_attr = false,
+  Boolean                 $enable_quota             = $beegfs::enable_quota,
+  Boolean                 $enable_acl               = $beegfs::enable_acl,
+  Stdlib::AbsolutePath    $admon_db_file            = $beegfs::admon_db_file,
 ) inherits beegfs {
 
   $_release_major = beegfs::release_to_major($beegfs::release)
@@ -42,6 +44,16 @@ class beegfs::admon (
     group   => $group,
     mode    => '0644',
     content => template('beegfs/interfaces.erb'),
+    require => Package['beegfs-admon'],
+  }
+
+  file { $networks_file:
+    ensure => $networks ? { undef => absent, default => present },
+    owner   => $user,
+    group   => $group,
+    mode    => '0644',
+    content => template('beegfs/networks.erb'),
+    require => Package['beegfs-admon'],
   }
 
   file { '/etc/beegfs/beegfs-admon.conf':
@@ -52,6 +64,7 @@ class beegfs::admon (
     require => [
       Package['beegfs-mgmtd'],
       File[$interfaces_file],
+      File[$networks_file],
     ],
   }
 
@@ -63,10 +76,12 @@ class beegfs::admon (
     require    => [
       Package['beegfs-admon'],
       File[$interfaces_file],
+      File[$networks_file],
     ],
     subscribe  => [
       File['/etc/beegfs/beegfs-admon.conf'],
       File[$interfaces_file],
+      File[$networks_file],
     ],
   }
 

--- a/manifests/meta.pp
+++ b/manifests/meta.pp
@@ -3,23 +3,25 @@
 # This module manages beegfs meta service
 #
 class beegfs::meta (
-  Boolean              $enable               = true,
-  Stdlib::AbsolutePath $meta_directory       = $beegfs::meta_directory,
-  Boolean              $allow_first_run_init = true,
-  Stdlib::Host         $mgmtd_host           = $beegfs::mgmtd_host,
-  Beegfs::LogDir       $log_dir              = $beegfs::log_dir,
-  Beegfs::LogType      $log_type             = $beegfs::log_type,
-  Beegfs::LogLevel     $log_level            = $beegfs::log_level,
-  String               $user                 = $beegfs::user,
-  String               $group                = $beegfs::group,
-  $package_ensure                            = lookup('beegfs::package_ensure', String, undef, $beegfs::package_ensure),
-  Array[String]        $interfaces           = ['eth0'],
-  Stdlib::AbsolutePath $interfaces_file      = '/etc/beegfs/interfaces.meta',
-  Boolean              $enable_acl           = $beegfs::enable_acl,
-  Stdlib::Port         $meta_tcp_port        = $beegfs::meta_tcp_port,
-  Stdlib::Port         $meta_udp_port        = $beegfs::meta_udp_port,
-  Stdlib::Port         $mgmtd_tcp_port       = $beegfs::mgmtd_tcp_port,
-  Stdlib::Port         $mgmtd_udp_port       = $beegfs::mgmtd_udp_port,
+  Boolean                 $enable               = true,
+  Stdlib::AbsolutePath    $meta_directory       = $beegfs::meta_directory,
+  Boolean                 $allow_first_run_init = true,
+  Stdlib::Host            $mgmtd_host           = $beegfs::mgmtd_host,
+  Beegfs::LogDir          $log_dir              = $beegfs::log_dir,
+  Beegfs::LogType         $log_type             = $beegfs::log_type,
+  Beegfs::LogLevel        $log_level            = $beegfs::log_level,
+  String                  $user                 = $beegfs::user,
+  String                  $group                = $beegfs::group,
+  $package_ensure                               = lookup('beegfs::package_ensure', String, undef, $beegfs::package_ensure),
+  Array[String]           $interfaces           = ['eth0'],
+  Stdlib::AbsolutePath    $interfaces_file      = '/etc/beegfs/interfaces.meta',
+  Optional[Array[String]] $networks             = undef,
+  Stdlib::AbsolutePath    $networks_file        = '/etc/beegfs/networks.meta',
+  Boolean                 $enable_acl           = $beegfs::enable_acl,
+  Stdlib::Port            $meta_tcp_port        = $beegfs::meta_tcp_port,
+  Stdlib::Port            $meta_udp_port        = $beegfs::meta_udp_port,
+  Stdlib::Port            $mgmtd_tcp_port       = $beegfs::mgmtd_tcp_port,
+  Stdlib::Port            $mgmtd_udp_port       = $beegfs::mgmtd_udp_port,
 
 ) inherits ::beegfs {
 
@@ -39,6 +41,15 @@ class beegfs::meta (
     require => Package['beegfs-meta'],
   }
 
+  file { $networks_file:
+    ensure => $networks ? { undef => absent, default => present },
+    owner   => $user,
+    group   => $group,
+    mode    => '0644',
+    content => template('beegfs/networks.erb'),
+    require => Package['beegfs-meta'],
+  }
+
   file { '/etc/beegfs/beegfs-meta.conf':
     ensure  => present,
     owner   => $user,
@@ -47,6 +58,7 @@ class beegfs::meta (
     content => template("beegfs/${_release_major}/beegfs-meta.conf.erb"),
     require => [
       File[$interfaces_file],
+      File[$networks_file],
       Package['beegfs-meta'],
     ],
   }
@@ -59,7 +71,8 @@ class beegfs::meta (
     require    => File['/etc/beegfs/beegfs-meta.conf'],
     subscribe  => [
       File['/etc/beegfs/beegfs-meta.conf'],
-      File[$interfaces_file]
+      File[$interfaces_file],
+      File[$networks_file],
     ],
   }
 }

--- a/manifests/mgmtd.pp
+++ b/manifests/mgmtd.pp
@@ -3,28 +3,30 @@
 # This module manages BeeGFS mgmtd
 #
 class beegfs::mgmtd (
-  Boolean              $enable                        = true,
-  Stdlib::AbsolutePath $directory                     = '/srv/beegfs/mgmtd',
-  Boolean              $allow_first_run_init          = true,
-  Integer[0,default]   $client_auto_remove_mins       = $beegfs::client_auto_remove_mins,
-  Beegfs::ByteAmount   $meta_space_low_limit          = $beegfs::meta_space_low_limit,
-  Beegfs::ByteAmount   $meta_space_emergency_limit    = $beegfs::meta_space_emergency_limit,
-  Beegfs::ByteAmount   $storage_space_low_limit       = $beegfs::storage_space_low_limit,
-  Beegfs::ByteAmount   $storage_space_emergency_limit = $beegfs::storage_space_emergency_limit,
-  $version                                            = $beegfs::version,
-  Beegfs::LogDir       $log_dir                       = $beegfs::log_dir,
-  Beegfs::LogType      $log_type                      = $beegfs::log_type,
-  Beegfs::LogLevel     $log_level                     = 2,
-  String               $user                          = $beegfs::user,
-  String               $group                         = $beegfs::group,
-  $package_ensure                                     = $beegfs::package_ensure,
-  Array[String]        $interfaces                    = ['eth0'],
-  Stdlib::AbsolutePath $interfaces_file               = '/etc/beegfs/interfaces.mgmtd',
-  Boolean              $enable_quota                  = $beegfs::enable_quota,
-  Boolean              $allow_new_servers             = $beegfs::allow_new_servers,
-  Boolean              $allow_new_targets             = $beegfs::allow_new_targets,
-  Stdlib::Port         $mgmtd_tcp_port                = $beegfs::mgmtd_tcp_port,
-  Stdlib::Port         $mgmtd_udp_port                = $beegfs::mgmtd_udp_port,
+  Boolean                 $enable                        = true,
+  Stdlib::AbsolutePath    $directory                     = '/srv/beegfs/mgmtd',
+  Boolean                 $allow_first_run_init          = true,
+  Integer[0,default]      $client_auto_remove_mins       = $beegfs::client_auto_remove_mins,
+  Beegfs::ByteAmount      $meta_space_low_limit          = $beegfs::meta_space_low_limit,
+  Beegfs::ByteAmount      $meta_space_emergency_limit    = $beegfs::meta_space_emergency_limit,
+  Beegfs::ByteAmount      $storage_space_low_limit       = $beegfs::storage_space_low_limit,
+  Beegfs::ByteAmount      $storage_space_emergency_limit = $beegfs::storage_space_emergency_limit,
+  $version                                               = $beegfs::version,
+  Beegfs::LogDir          $log_dir                       = $beegfs::log_dir,
+  Beegfs::LogType         $log_type                      = $beegfs::log_type,
+  Beegfs::LogLevel        $log_level                     = 2,
+  String                  $user                          = $beegfs::user,
+  String                  $group                         = $beegfs::group,
+  $package_ensure                                        = $beegfs::package_ensure,
+  Array[String]           $interfaces                    = ['eth0'],
+  Stdlib::AbsolutePath    $interfaces_file               = '/etc/beegfs/interfaces.mgmtd',
+  Optional[Array[String]] $networks                      = undef,
+  Stdlib::AbsolutePath    $networks_file                 = '/etc/beegfs/networks.mgmtd',
+  Boolean                 $enable_quota                  = $beegfs::enable_quota,
+  Boolean                 $allow_new_servers             = $beegfs::allow_new_servers,
+  Boolean                 $allow_new_targets             = $beegfs::allow_new_targets,
+  Stdlib::Port            $mgmtd_tcp_port                = $beegfs::mgmtd_tcp_port,
+  Stdlib::Port            $mgmtd_udp_port                = $beegfs::mgmtd_udp_port,
 ) inherits ::beegfs {
 
   $_release_major = beegfs::release_to_major($beegfs::release)
@@ -51,6 +53,15 @@ class beegfs::mgmtd (
     require => Package['beegfs-mgmtd'],
   }
 
+  file { $networks_file:
+    ensure => $networks ? { undef => absent, default => present },
+    owner   => $user,
+    group   => $group,
+    mode    => '0644',
+    content => template('beegfs/networks.erb'),
+    require => Package['beegfs-mgmtd'],
+  }
+
   file { '/etc/beegfs/beegfs-mgmtd.conf':
     ensure  => present,
     owner   => $user,
@@ -59,6 +70,7 @@ class beegfs::mgmtd (
     require => [
       Package['beegfs-mgmtd'],
       File[$interfaces_file],
+      File[$networks_file],
     ],
   }
 
@@ -70,10 +82,12 @@ class beegfs::mgmtd (
     require    => [
       Package['beegfs-mgmtd'],
       File[$interfaces_file],
+      File[$networks_file],
     ],
     subscribe  => [
       File['/etc/beegfs/beegfs-mgmtd.conf'],
       File[$interfaces_file],
+      File[$networks_file],
     ],
   }
 }

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -15,6 +15,8 @@ class beegfs::storage (
                               $package_ensure       = $beegfs::package_ensure,
   Array[String]               $interfaces           = ['eth0'],
   Stdlib::AbsolutePath        $interfaces_file      = '/etc/beegfs/interfaces.storage',
+  Optional[Array[String]]     $networks             = undef,
+  Stdlib::AbsolutePath        $networks_file        = '/etc/beegfs/networks.storage',
   Stdlib::Port                $mgmtd_tcp_port       = 8008,
   Stdlib::Port                $mgmtd_udp_port       = 8008,
   Boolean                     $enable_quota         = $beegfs::enable_quota,
@@ -43,6 +45,15 @@ class beegfs::storage (
     require => Package['beegfs-storage'],
   }
 
+  file { $networks_file:
+    ensure => $networks ? { undef => absent, default => present },
+    owner   => $user,
+    group   => $group,
+    mode    => '0644',
+    content => template('beegfs/networks.erb'),
+    require => Package['beegfs-storage'],
+  }
+
   file { '/etc/beegfs/beegfs-storage.conf':
     ensure  => present,
     owner   => $user,
@@ -51,6 +62,7 @@ class beegfs::storage (
     content => template("beegfs/${_release_major}/beegfs-storage.conf.erb"),
     require => [
       File[$interfaces_file],
+      File[$networks_file],
       Package['beegfs-storage'],
     ],
   }
@@ -64,6 +76,7 @@ class beegfs::storage (
     subscribe  => [
       File['/etc/beegfs/beegfs-storage.conf'],
       File[$interfaces_file],
+      File[$networks_file],
     ],
   }
 }

--- a/templates/7/beegfs-admon.conf.erb
+++ b/templates/7/beegfs-admon.conf.erb
@@ -36,7 +36,7 @@ connAuthFile                 =
 connFallbackExpirationSecs   = 900
 connMaxInternodeNum          = 3
 connInterfacesFile           =
-connNetFilterFile            =
+connNetFilterFile            = <% if @networks %><%= @networks_file %><% end %>
 connTcpOnlyFilterFile        =
 
 logType                      = <%= @log_type %>

--- a/templates/7/beegfs-client.conf.erb
+++ b/templates/7/beegfs-client.conf.erb
@@ -34,7 +34,7 @@ connFallbackExpirationSecs    = 900
 connInterfacesFile            = <%= @interfaces_file %>
 connMaxInternodeNum           = 12
 connMaxConcurrentAttempts     = 0
-connNetFilterFile             =
+connNetFilterFile             = <% if @networks %><%= @networks_file %><% end %>
 
 connUseRDMA                   = true
 connRDMABufNum                = 70

--- a/templates/7/beegfs-meta.conf.erb
+++ b/templates/7/beegfs-meta.conf.erb
@@ -37,7 +37,7 @@ connMgmtdPortTCP             = <%= @mgmtd_tcp_port %>
 connMgmtdPortUDP             = <%= @mgmtd_udp_port %>
 connPortShift                = 0
 
-connNetFilterFile            =
+connNetFilterFile            = <% if @networks %><%= @networks_file %><% end %>
 
 connUseRDMA                  = true
 connRDMATypeOfService        = 0

--- a/templates/7/beegfs-mgmtd.conf.erb
+++ b/templates/7/beegfs-mgmtd.conf.erb
@@ -31,7 +31,7 @@ connBacklogTCP                         = 128
 connInterfacesFile                     = <%= @interfaces_file %>
 connMgmtdPortTCP                       = <%= @mgmtd_tcp_port %>
 connMgmtdPortUDP                       = <%= @mgmtd_udp_port %>
-connNetFilterFile                      =
+connNetFilterFile                      = <% if @networks %><%= @networks_file %><% end %>
 connPortShift                          = 0
 
 logType                                = <%= @log_type %>

--- a/templates/7/beegfs-storage.conf.erb
+++ b/templates/7/beegfs-storage.conf.erb
@@ -36,7 +36,7 @@ connStoragePortTCP           = <%= @storage_tcp_port %>
 connStoragePortUDP           = <%= @storage_udp_port %>
 connPortShift                = 0
 
-connNetFilterFile            =
+connNetFilterFile            = <% if @networks %><%= @networks_file %><% end %>
 
 connUseRDMA                  = true
 connRDMATypeOfService        = 0

--- a/templates/networks.erb
+++ b/templates/networks.erb
@@ -1,0 +1,5 @@
+<% if @networks -%>
+<% @networks.each do |n| -%>
+<%= n %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Add the networks and networks_file parameters for the client, meta,
storage, mgmtd and dmon classes. This allows to specify the
connNetFilterFile configuration parameter. If no networks are supplied,
the configuration is unchanged. Only if a list of networks is supplied,
the file will be written and set in the configuration.

Signed-off-by: Peter Verraedt <peter.verraedt@kuleuven.be>