### PR TITLE
Better client resource ordering

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -45,7 +45,7 @@ class beegfs::client (
     group   => $group,
     mode    => '0644',
     content => template("beegfs/${_release_major}/beegfs-helperd.conf.erb"),
-    require => Anchor['beegfs::repo'],
+    require => Package['beegfs-helperd'],
   }
 
   file { $interfaces_file:
@@ -90,7 +90,7 @@ class beegfs::client (
     group   => $group,
     mode    => '0644',
     content => template("beegfs/${_release_major}/beegfs-client-autobuild.conf.erb"),
-    require => Anchor['beegfs::repo'],
+    require => Package['beegfs-client'],
   }
 
   exec { '/etc/init.d/beegfs-client rebuild':

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -45,6 +45,7 @@ class beegfs::client (
     group   => $group,
     mode    => '0644',
     content => template("beegfs/${_release_major}/beegfs-helperd.conf.erb"),
+    require => Anchor['beegfs::repo'],
   }
 
   file { $interfaces_file:
@@ -89,6 +90,7 @@ class beegfs::client (
     group   => $group,
     mode    => '0644',
     content => template("beegfs/${_release_major}/beegfs-client-autobuild.conf.erb"),
+    require => Anchor['beegfs::repo'],
   }
 
   exec { '/etc/init.d/beegfs-client rebuild':
@@ -104,7 +106,7 @@ class beegfs::client (
 
   package { 'beegfs-client':
     ensure  => $package_ensure,
-    require => Anchor['beegfs::kernel_dev'],
+    require => [Anchor['beegfs::kernel_dev'], Anchor['beegfs::repo']],
   }
 
   service { 'beegfs-helperd':
@@ -119,7 +121,7 @@ class beegfs::client (
     owner   => $user,
     group   => $group,
     mode    => '0644',
-    require => Package['beegfs-client'],
+    require => [Package['beegfs-client'], Anchor['beegfs::repo']],
   }
 
   service { 'beegfs-client':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,7 +41,7 @@ class beegfs::install(
 
   package { 'beegfs-utils':
     ensure  => $package_ensure,
-    require => [Anchor['beegfs::repo::end']],
+    require => [Anchor['beegfs::repo']],
   }
 
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -9,21 +9,18 @@ class beegfs::repo(
   $manage_repo    = $beegfs::manage_repo,
   $package_source = $beegfs::package_source,
 ) inherits beegfs {
-  anchor { 'beegfs::repo::begin': }
-  anchor { 'beegfs::repo::end': }
+  anchor { 'beegfs::repo': }
 
   case $facts['os']['family'] {
     'Debian': {
       class { 'beegfs::repo::debian':
         release => $release,
-        require => Anchor['beegfs::repo::begin'],
-        before  => Anchor['beegfs::repo::end'],
+        before  => Anchor['beegfs::repo'],
       }
     }
     'RedHat': {
       class { 'beegfs::repo::redhat':
-        require => Anchor['beegfs::repo::begin'],
-        before  => Anchor['beegfs::repo::end'],
+        before  => Anchor['beegfs::repo'],
       }
     }
     default: {

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,9 +1,10 @@
 # Manages APT repositories for Debian distros
 
 class beegfs::repo::debian (
-  Boolean         $manage_repo    = true,
-  Enum['beegfs']  $package_source = $beegfs::package_source,
-  Beegfs::Release $release        = $beegfs::release,
+  Boolean          $manage_repo    = true,
+  Enum['beegfs']   $package_source = $beegfs::package_source,
+  Beegfs::Release  $release        = $beegfs::release,
+  Optional[String] $gpg_key_id     = '055D000F1A9A092763B1F0DD14E8E08064497785'
 ) {
 
   anchor { 'beegfs::apt_repo' : }
@@ -59,7 +60,7 @@ class beegfs::repo::debian (
           architecture => 'amd64',
           release      => $_os_release,
           key          => {
-            'id'     => '055D000F1A9A092763B1F0DD14E8E08064497785',
+            'id'     => $gpg_key_id,
             'source' => "http://www.beegfs.com/release/beegfs_${_release}/gpg/DEB-GPG-KEY-beegfs",
           },
           include      => {

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -60,7 +60,7 @@ class beegfs::repo::debian (
           release      => $_os_release,
           key          => {
             'id'     => '055D000F1A9A092763B1F0DD14E8E08064497785',
-            'source' => 'http://www.beegfs.com/release/latest-stable/gpg/DEB-GPG-KEY-beegfs',
+            'source' => "http://www.beegfs.com/release/beegfs_${_release}/gpg/DEB-GPG-KEY-beegfs",
           },
           include      => {
             'src' => false,

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -167,10 +167,7 @@ describe 'beegfs::client' do
         )
     end
     it do
-      is_expected.to contain_package('linux-headers-amd64')
-        .with(
-          'ensure' => 'present',
-        )
+      is_expected.to contain_package('linux-headers-amd64').with_ensure(%r{present|installed})
     end
     it do
       is_expected.to contain_package('beegfs-helperd')
@@ -184,9 +181,9 @@ describe 'beegfs::client' do
     is_expected.to contain_file('/etc/beegfs/interfaces.client')
       .with(
         'ensure' => 'present',
-    'owner'   => user,
-    'group'   => group,
-    'mode'    => '0644',
+        'owner'   => user,
+        'group'   => group,
+        'mode'    => '0644',
       ).with_content(%r{eth0})
   end
 
@@ -204,9 +201,9 @@ describe 'beegfs::client' do
       is_expected.to contain_file('/etc/beegfs/client.itf')
         .with(
           'ensure' => 'present',
-      'owner'   => user,
-      'group'   => group,
-      'mode'    => '0644',
+          'owner'   => user,
+          'group'   => group,
+          'mode'    => '0644',
         ).with_content(%r{ib0})
     end
 

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -99,7 +99,7 @@ describe 'beegfs::client' do
         'location' => 'http://www.beegfs.io/release/beegfs_2015.03',
         'repos'    => 'non-free',
         'release'  => "deb#{major}",
-        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/latest-stable/gpg/DEB-GPG-KEY-beegfs' },
+        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/beegfs_2015.03/gpg/DEB-GPG-KEY-beegfs' },
         'include'  => { 'src' => false, 'deb' => true },
       )
     }
@@ -325,7 +325,7 @@ describe 'beegfs::client' do
         'location' => 'http://www.beegfs.io/release/beegfs_6',
         'repos'    => 'non-free',
         'release'  => 'deb7',
-        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/latest-stable/gpg/DEB-GPG-KEY-beegfs' },
+        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/beegfs_6/gpg/DEB-GPG-KEY-beegfs' },
         'include'  => { 'src' => false, 'deb' => true },
       )
     }

--- a/spec/classes/debian_spec.rb
+++ b/spec/classes/debian_spec.rb
@@ -43,7 +43,7 @@ describe 'beegfs::client' do
         'location' => 'http://www.beegfs.io/release/beegfs_7_1',
         'repos'    => 'non-free',
         'release'  => 'stretch',
-        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/latest-stable/gpg/DEB-GPG-KEY-beegfs' },
+        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/beegfs_7_1/gpg/DEB-GPG-KEY-beegfs' },
         'include'  => { 'src' => false, 'deb' => true },
       )
     }
@@ -96,7 +96,7 @@ describe 'beegfs::client' do
         'location' => 'http://www.beegfs.io/release/beegfs_7_1',
         'repos'    => 'non-free',
         'release'  => 'buster', # TODO: 7.1.x has no buster release
-        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/latest-stable/gpg/DEB-GPG-KEY-beegfs' },
+        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/beegfs_7_1/gpg/DEB-GPG-KEY-beegfs' },
         'include'  => { 'src' => false, 'deb' => true },
       )
     }
@@ -116,7 +116,7 @@ describe 'beegfs::client' do
         'location' => 'http://www.beegfs.io/release/beegfs_7.2',
         'repos'    => 'non-free',
         'release'  => 'stretch',
-        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/latest-stable/gpg/DEB-GPG-KEY-beegfs' },
+        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/beegfs_7.2/gpg/DEB-GPG-KEY-beegfs' },
         'include'  => { 'src' => false, 'deb' => true },
       )
     }
@@ -136,7 +136,7 @@ describe 'beegfs::client' do
         'location' => 'http://www.beegfs.io/release/beegfs_7.1.5',
         'repos'    => 'non-free',
         'release'  => 'stretch',
-        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/latest-stable/gpg/DEB-GPG-KEY-beegfs' },
+        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/beegfs_7.1.5/gpg/DEB-GPG-KEY-beegfs' },
         'include'  => { 'src' => false, 'deb' => true },
       )
     }

--- a/spec/classes/debian_spec.rb
+++ b/spec/classes/debian_spec.rb
@@ -54,12 +54,11 @@ describe 'beegfs::client' do
           'ensure' => 'present',
         )
     end
+
     it do
-      is_expected.to contain_package('linux-headers-amd64')
-        .with(
-          'ensure' => 'present',
-        )
+      is_expected.to contain_package('linux-headers-amd64').with_ensure(%r{present|installed})
     end
+
     it do
       is_expected.to contain_package('beegfs-helperd')
         .with(

--- a/spec/classes/meta_spec.rb
+++ b/spec/classes/meta_spec.rb
@@ -242,7 +242,7 @@ describe 'beegfs::meta' do
         'location' => 'http://www.beegfs.io/release/beegfs_6',
         'repos'    => 'non-free',
         'release'  => 'deb7',
-        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/latest-stable/gpg/DEB-GPG-KEY-beegfs' },
+        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/beegfs_6/gpg/DEB-GPG-KEY-beegfs' },
         'include'  => { 'src' => false, 'deb' => true },
       )
     }

--- a/spec/classes/mgmtd_spec.rb
+++ b/spec/classes/mgmtd_spec.rb
@@ -177,7 +177,7 @@ describe 'beegfs::mgmtd' do
         'location' => 'http://www.beegfs.io/release/beegfs_6',
         'repos'    => 'non-free',
         'release'  => 'deb7',
-        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/latest-stable/gpg/DEB-GPG-KEY-beegfs' },
+        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/beegfs_6/gpg/DEB-GPG-KEY-beegfs' },
         'include'  => { 'src' => false, 'deb' => true },
       )
     }

--- a/spec/classes/redhat_spec.rb
+++ b/spec/classes/redhat_spec.rb
@@ -50,12 +50,11 @@ describe 'beegfs::client' do
           'ensure' => 'present',
         )
     end
+
     it do
-      is_expected.to contain_package('kernel-devel')
-        .with(
-          'ensure' => 'present',
-        )
+      is_expected.to contain_package('kernel-devel').with_ensure(%r{present|installed})
     end
+
     it do
       is_expected.to contain_package('beegfs-helperd')
         .with(
@@ -92,12 +91,11 @@ describe 'beegfs::client' do
           'ensure' => 'present',
         )
     end
-    it do
-      is_expected.to contain_package('kernel-devel')
-        .with(
-          'ensure' => 'present',
-        )
-    end
+
+    it {
+      is_expected.to contain_package('kernel-devel').with_ensure(%r{present|installed})
+    }
+
     it do
       is_expected.to contain_package('beegfs-helperd')
         .with(

--- a/spec/classes/storage_spec.rb
+++ b/spec/classes/storage_spec.rb
@@ -294,7 +294,7 @@ describe 'beegfs::storage' do
         'location' => 'http://www.beegfs.io/release/beegfs_6',
         'repos'    => 'non-free',
         'release'  => 'deb7',
-        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/latest-stable/gpg/DEB-GPG-KEY-beegfs' },
+        'key'      => { 'id' => '055D000F1A9A092763B1F0DD14E8E08064497785', 'source' => 'http://www.beegfs.com/release/beegfs_6/gpg/DEB-GPG-KEY-beegfs' },
         'include'  => { 'src' => false, 'deb' => true },
       )
     }


### PR DESCRIPTION
Don't cofigure files before installing its packages. GPG keys are fetched from pinned release