### PR TITLE
Add conn_auth_file parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@ class beegfs (
   Boolean                     $enable_acl                    = false,
   Boolean                     $allow_user_set_pattern        = false,
   Boolean                     $enable_rdma                   = true,
+  Optional[String]            $conn_auth_file                = undef,
   Boolean                     $allow_new_servers             = false,
   Boolean                     $allow_new_targets             = false,
   Stdlib::Port                $admon_http_port               = 8000,

--- a/templates/2015.03/beegfs-client.conf.erb
+++ b/templates/2015.03/beegfs-client.conf.erb
@@ -22,7 +22,7 @@ sysMgmtdHost                  = <%= @mgmtd_host %>
 # --- Section 1.2: [Advanced Settings] ---
 #
 
-connAuthFile                  =
+connAuthFile                  = <%= $conn_auth_file %>
 connClientPortUDP             = <%= @client_udp_port %>
 connHelperdPortTCP            = <%= @helperd_tcp_port %>
 connMgmtdPortTCP              = <%= @mgmtd_tcp_port %>

--- a/templates/2015.03/beegfs-helperd.conf.erb
+++ b/templates/2015.03/beegfs-helperd.conf.erb
@@ -15,7 +15,7 @@
 # --- Section 1: [Settings] ---
 #
 
-connAuthFile       =
+connAuthFile       = <%= $conn_auth_file %>
 connHelperdPortTCP = <%= @helperd_tcp_port %>
 connPortShift      = 0
 

--- a/templates/2015.03/beegfs-meta.conf.erb
+++ b/templates/2015.03/beegfs-meta.conf.erb
@@ -25,7 +25,7 @@ storeAllowFirstRunInit       = <%= @allow_first_run_init %>
 # --- Section 1.2: [Advanced Settings] ---
 #
 
-connAuthFile                 =
+connAuthFile                 = <%= $conn_auth_file %>
 connBacklogTCP               = 128
 connFallbackExpirationSecs   = 900
 connInterfacesFile           = <%= @interfaces_file %>

--- a/templates/2015.03/beegfs-mgmtd.conf.erb
+++ b/templates/2015.03/beegfs-mgmtd.conf.erb
@@ -26,7 +26,7 @@ sysAllowNewTargets       = <%= @allow_new_targets %>
 # --- Section 1.2: [Advanced Settings] ---
 #
 
-connAuthFile                           =
+connAuthFile                           = <%= $conn_auth_file %>
 connBacklogTCP                         = 128
 connInterfacesFile                     = <%= @interfaces_file %>
 connMgmtdPortTCP                       = 8008

--- a/templates/2015.03/beegfs-storage.conf.erb
+++ b/templates/2015.03/beegfs-storage.conf.erb
@@ -25,7 +25,7 @@ storeAllowFirstRunInit       = <%= @allow_first_run_init %>
 # --- Section 1.2: [Advanced Settings] ---
 #
 
-connAuthFile                 =
+connAuthFile                 = <%= $conn_auth_file %>
 connBacklogTCP               = 128
 connInterfacesFile           = <%= @interfaces_file %>
 connMaxInternodeNum          = 12

--- a/templates/6/beegfs-client.conf.erb
+++ b/templates/6/beegfs-client.conf.erb
@@ -22,7 +22,7 @@ sysMgmtdHost                  = <%= @mgmtd_host %>
 # --- Section 1.2: [Advanced Settings] ---
 #
 
-connAuthFile                  =
+connAuthFile                  = <%= $conn_auth_file %>
 connClientPortUDP             = <%= @client_udp_port %>
 connHelperdPortTCP            = <%= @helperd_tcp_port %>
 connMgmtdPortTCP              = <%= @mgmtd_tcp_port %>

--- a/templates/6/beegfs-helperd.conf.erb
+++ b/templates/6/beegfs-helperd.conf.erb
@@ -15,7 +15,7 @@
 # --- Section 1: [Settings] ---
 #
 
-connAuthFile       =
+connAuthFile       = <%= $conn_auth_file %>
 connHelperdPortTCP = <%= @helperd_tcp_port %>
 connPortShift      = 0
 

--- a/templates/6/beegfs-meta.conf.erb
+++ b/templates/6/beegfs-meta.conf.erb
@@ -25,7 +25,7 @@ storeAllowFirstRunInit       = <%= @allow_first_run_init %>
 # --- Section 1.2: [Advanced Settings] ---
 #
 
-connAuthFile                 =
+connAuthFile                 = <%= $conn_auth_file %>
 connBacklogTCP               = 128
 connFallbackExpirationSecs   = 900
 connInterfacesFile           = <%= @interfaces_file %>

--- a/templates/6/beegfs-mgmtd.conf.erb
+++ b/templates/6/beegfs-mgmtd.conf.erb
@@ -26,7 +26,7 @@ sysAllowNewTargets       = <%= @allow_new_targets %>
 # --- Section 1.2: [Advanced Settings] ---
 #
 
-connAuthFile                           =
+connAuthFile                           = <%= $conn_auth_file %>
 connBacklogTCP                         = 128
 connInterfacesFile                     = <%= @interfaces_file %>
 connMgmtdPortTCP                       = 8008

--- a/templates/6/beegfs-storage.conf.erb
+++ b/templates/6/beegfs-storage.conf.erb
@@ -25,7 +25,7 @@ storeAllowFirstRunInit       = <%= @allow_first_run_init %>
 # --- Section 1.2: [Advanced Settings] ---
 #
 
-connAuthFile                 =
+connAuthFile                 = <%= $conn_auth_file %>
 connBacklogTCP               = 128
 connInterfacesFile           = <%= @interfaces_file %>
 connMaxInternodeNum          = 12

--- a/templates/7/beegfs-admon.conf.erb
+++ b/templates/7/beegfs-admon.conf.erb
@@ -32,7 +32,7 @@ connMgmtdPortTCP             = <%= @mgmtd_tcp_port %>
 connMgmtdPortUDP             = <%= @mgmtd_udp_port %>
 connPortShift                = 0
 
-connAuthFile                 =
+connAuthFile                 = <%= $conn_auth_file %>
 connFallbackExpirationSecs   = 900
 connMaxInternodeNum          = 3
 connInterfacesFile           =

--- a/templates/7/beegfs-client.conf.erb
+++ b/templates/7/beegfs-client.conf.erb
@@ -22,7 +22,7 @@ sysMgmtdHost                  = <%= @mgmtd_host %>
 # --- Section 1.2: [Advanced Settings] ---
 #
 
-connAuthFile                  =
+connAuthFile                  = <%= $conn_auth_file %>
 connClientPortUDP             = <%= @client_udp_port %>
 connHelperdPortTCP            = <%= @helperd_tcp_port %>
 connMgmtdPortTCP              = <%= @mgmtd_tcp_port %>

--- a/templates/7/beegfs-helperd.conf.erb
+++ b/templates/7/beegfs-helperd.conf.erb
@@ -15,7 +15,7 @@
 # --- Section 1: [Settings] ---
 #
 
-connAuthFile       =
+connAuthFile       = <%= $conn_auth_file %>
 connHelperdPortTCP = <%= @helperd_tcp_port %>
 connPortShift      = 0
 

--- a/templates/7/beegfs-meta.conf.erb
+++ b/templates/7/beegfs-meta.conf.erb
@@ -25,7 +25,7 @@ storeAllowFirstRunInit       = <%= @allow_first_run_init %>
 # --- Section 1.2: [Advanced Settings] ---
 #
 
-connAuthFile                 =
+connAuthFile                 = <%= $conn_auth_file %>
 connBacklogTCP               = 128
 connFallbackExpirationSecs   = 900
 connInterfacesFile           = <%= @interfaces_file %>

--- a/templates/7/beegfs-mgmtd.conf.erb
+++ b/templates/7/beegfs-mgmtd.conf.erb
@@ -26,7 +26,7 @@ sysAllowNewTargets       = <%= @allow_new_targets %>
 # --- Section 1.2: [Advanced Settings] ---
 #
 
-connAuthFile                           =
+connAuthFile                           = <%= $conn_auth_file %>
 connBacklogTCP                         = 128
 connInterfacesFile                     = <%= @interfaces_file %>
 connMgmtdPortTCP                       = <%= @mgmtd_tcp_port %>

--- a/templates/7/beegfs-storage.conf.erb
+++ b/templates/7/beegfs-storage.conf.erb
@@ -25,7 +25,7 @@ storeAllowFirstRunInit       = <%= @allow_first_run_init %>
 # --- Section 1.2: [Advanced Settings] ---
 #
 
-connAuthFile                 =
+connAuthFile                 = <%= $conn_auth_file %>
 connBacklogTCP               = 128
 connInterfacesFile           = <%= @interfaces_file %>
 connMaxInternodeNum          = 12


### PR DESCRIPTION
From beegfs 7.3 onwards, setting a conn_auth_file (or explicitly setting
connDisableAuthentication) is required. We add an option here to define
a conn auth file.

Signed-off-by: Peter Verraedt <peter.verraedt@kuleuven.be>