### PR TITLE
Add the sysNoEnterpriseFeatureMsg client option

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -28,6 +28,7 @@
 # @param enable_rdma
 # @param remote_fsync
 # @param conn_auth_file
+# @param sys_no_ent_feat_msg
 # @param manage_service
 #    Whether service should be managed by puppet and restarted upon config changes
 #
@@ -63,6 +64,7 @@ class beegfs::client (
   Optional[Stdlib::AbsolutePath] $conn_auth_file           = $beegfs::conn_auth_file,
   Boolean                        $manage_service           = true,
   Optional[String]               $sys_file_event_log_mask  = undef,
+  Optional[Boolean]              $sys_no_ent_feat_msg      = undef,
 ) inherits beegfs {
   stdlib::ensure_packages($kernel_packages, {
       'ensure' => $kernel_ensure,

--- a/templates/7/beegfs-client.conf.erb
+++ b/templates/7/beegfs-client.conf.erb
@@ -77,6 +77,7 @@ sysACLsEnabled                = <%= @enable_acl %>
 <% if @sys_no_ent_feat_msg -%>
 sysNoEnterpriseFeatureMsg = <%= @sys_no_ent_feat_msg %>
 <% end -%>
+
 #
 # --- Section 2: [Mount Options] ---
 #

--- a/templates/7/beegfs-client.conf.erb
+++ b/templates/7/beegfs-client.conf.erb
@@ -74,7 +74,9 @@ tuneUseGlobalFileLocks        = false
 
 sysACLsEnabled                = <%= @enable_acl %>
 
-
+<% if @sys_no_ent_feat_msg -%>
+sysNoEnterpriseFeatureMsg = <%= @sys_no_ent_feat_msg %>
+<% end -%>
 #
 # --- Section 2: [Mount Options] ---
 #


### PR DESCRIPTION
This allows you to disable the BeeGFS Enterprise EULA message on the clients. By default it won't do anything.

